### PR TITLE
#37 컬러 모드 Provider 세팅, 임시로 라이트모드로 제한

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gh-pages": "^6.2.0",
     "next": "15.0.3",
     "next-mdx-remote": "^5.0.0",
+    "next-themes": "^0.4.4",
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "react-scripts": "^5.0.1",

--- a/src/app/components/layout/Header.tsx
+++ b/src/app/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Link from "next/link";
 // import NavLink from "../common/NavLink";
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
+// import ColorThemeSwitch from "./theme/ColorThemeSwitch";
 
 // const menus: { route: string; name: string }[] = [
 // {
@@ -42,9 +43,14 @@ const Header = () => {
             일어나... 개발해야지
           </Link>
         </nav>
-        <div>
+        <div className="flex justify-end items-center gap-4">
+          {/* <ColorThemeSwitch /> */}
           <Link href="https://github.com/makepin2r" target="_blank">
-            <GitHubLogoIcon className="w-5 h-5 text-gray-700 hover:text-primary-500 transition-hover" />
+            <GitHubLogoIcon
+              width={20}
+              height={20}
+              className="text-gray-700 hover:text-primary-500 transition-hover"
+            />
           </Link>
         </div>
       </div>

--- a/src/app/components/layout/theme/ColorThemeProvider.tsx
+++ b/src/app/components/layout/theme/ColorThemeProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { ThemeProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes";
+
+const ColorThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="light" {...props}>
+      {children}
+    </ThemeProvider>
+  );
+};
+
+export default ColorThemeProvider;

--- a/src/app/components/layout/theme/ColorThemeSwitch.tsx
+++ b/src/app/components/layout/theme/ColorThemeSwitch.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { SunIcon, MoonIcon, DesktopIcon } from "@radix-ui/react-icons";
+
+const ColorThemeSwitch = () => {
+  const { theme, setTheme } = useTheme();
+  return (
+    <button>
+      {theme === "light" ? (
+        <SunIcon width={18} height={18} onClick={() => setTheme("dark")} />
+      ) : (
+        <MoonIcon width={18} height={18} onClick={() => setTheme("light")} />
+      )}
+    </button>
+  );
+};
+
+export default ColorThemeSwitch;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,11 +19,9 @@
   --primary-100: #fcd8ce;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: var(--black);
+  --foreground: var(--white);
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
+import ColorThemeProvider from "./components/layout/theme/ColorThemeProvider";
 import { blogTitle, blogDescription, baseDomain } from "@/config/const";
 
 const pretendard = localFont({
@@ -40,13 +41,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ko" suppressHydrationWarning>
       <body className={`${pretendard.className}`}>
-        <Header />
-        <main className="w-full max-w-[960px] mx-auto px-4 py-5 min-h-[calc(100vh-190px)]">
-          {children}
-        </main>
-        <Footer />
+        <ColorThemeProvider>
+          <Header />
+          <main className="w-full max-w-[960px] mx-auto px-4 py-5 min-h-[calc(100vh-190px)]">
+            {children}
+          </main>
+          <Footer />
+        </ColorThemeProvider>
       </body>
     </html>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ export default {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  darkMode: ['class'],
   theme: {
     screens: {
       sm: "640px",


### PR DESCRIPTION
## 변동 사항
- next-themes 이용해 ColorThemeProvider 정의
- 레이아웃에 ThemeProvider 적용

## 추가 변동 사항
- 라이트모드로 통일 (컬러 정의 안해서)